### PR TITLE
Implement Postman .env creation and rename method

### DIFF
--- a/main.py
+++ b/main.py
@@ -108,8 +108,8 @@ def main(
             logger.info("\n✅ Endpoint listing completed successfully!")
         else:
             if not config.use_existing_framework:
-                framework_generator.setup_framework(api_definitions)
                 framework_generator.create_env_file(api_definitions)
+                framework_generator.setup_framework(api_definitions)
 
             framework_generator.generate(api_definitions, config.generate)
             test_files = framework_generator.run_final_checks(config.generate)

--- a/src/adapters/processors_adapter.py
+++ b/src/adapters/processors_adapter.py
@@ -29,4 +29,8 @@ class ProcessorsAdapter(containers.DeclarativeContainer):
         file_service=file_service,
         config=config,
     )
-    postman_processor = providers.Factory(PostmanProcessor, file_service=file_service)
+    postman_processor = providers.Factory(
+        PostmanProcessor,
+        file_service=file_service,
+        config=config,
+    )

--- a/src/framework_generator.py
+++ b/src/framework_generator.py
@@ -105,7 +105,7 @@ class FrameworkGenerator:
     def create_env_file(self, api_definition: APIDefinition):
         """Generate the .env file from the provided API definition"""
         try:
-            self.api_processor.extract_env_vars(api_definition)
+            self.api_processor.create_dot_env(api_definition)
         except Exception as e:
             self._log_error("Error creating .env file", e)
             raise

--- a/src/models/api_definition.py
+++ b/src/models/api_definition.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 from src.models.api_def import APIDef
 from src.models.api_path import APIPath
@@ -13,10 +13,15 @@ class APIDefinition:
 
     definitions: List[APIDef | RequestData] = field(default_factory=list)
     endpoints: Optional[List[str]] = None
+    variables: List[Dict[str, str]] = field(default_factory=list)
 
     def add_definition(self, definition: APIDef) -> None:
         """Add a definition to the list"""
         self.definitions.append(definition)
+
+    def add_variable(self, key: str, value: str) -> None:
+        """Add a variable to the list"""
+        self.variables.append({"key": key, "value": value})
 
     def get_paths(self) -> List[APIPath]:
         """Get all path definitions"""
@@ -50,4 +55,8 @@ class APIDefinition:
 
     def to_json(self) -> dict:
         """Convert to JSON-serializable dictionary"""
-        return {"definitions": [d.to_json() for d in self.definitions], "endpoints": self.endpoints}
+        return {
+            "definitions": [d.to_json() for d in self.definitions],
+            "endpoints": self.endpoints,
+            "variables": self.variables,
+        }

--- a/src/processors/api_processor.py
+++ b/src/processors/api_processor.py
@@ -57,7 +57,7 @@ class APIProcessor(ABC):
         pass
 
     @abstractmethod
-    def create_dot_env(self, api_definition: APIDefinition) -> List[str]:
+    def create_dot_env(self, api_definition: APIDefinition) -> None:
         """Create the `.env` file from the API definition and return variable names"""
         pass
 

--- a/src/processors/api_processor.py
+++ b/src/processors/api_processor.py
@@ -57,8 +57,8 @@ class APIProcessor(ABC):
         pass
 
     @abstractmethod
-    def extract_env_vars(self, api_definition: APIDefinition) -> List[str]:
-        """Extract environment variables from the API definition"""
+    def create_dot_env(self, api_definition: APIDefinition) -> List[str]:
+        """Create the `.env` file from the API definition and return variable names"""
         pass
 
     @abstractmethod

--- a/src/processors/postman/postman_utils.py
+++ b/src/processors/postman/postman_utils.py
@@ -3,7 +3,6 @@ import re
 from typing import Any, Dict, Iterable, List
 from urllib.parse import parse_qsl
 
-from ...models import APIDefinition
 from ...processors.postman.models import RequestData, VerbInfo
 
 
@@ -13,6 +12,16 @@ class PostmanUtils:
     """
 
     numeric_only = r"^\d+$"
+
+    @staticmethod
+    def extract_variables(data: Any) -> List[Dict[str, str]]:
+        """Extract variables from Postman data"""
+        variables = []
+        if isinstance(data, dict) and "variable" in data:
+            for var in data["variable"]:
+                if isinstance(var, dict) and "key" in var and "value" in var:
+                    variables.append({"key": var["key"], "value": var["value"]})
+        return variables
 
     @staticmethod
     def extract_requests(data: Any, path: str = "") -> List[RequestData]:
@@ -163,17 +172,6 @@ class PostmanUtils:
             ev = item.get("event")
             return isinstance(ev, list) and any("request" in e for e in ev)
         return False
-
-    @staticmethod
-    def extract_env_vars(requests: APIDefinition) -> List[str]:
-        evs = set()
-        for r in requests.definitions:
-            if r.path.startswith("{{"):
-                m = re.match(r"\{\{(.*?)}}", r.path)
-                if m:
-                    evs.add(m.group(1))
-                    break
-        return list(evs)
 
     @staticmethod
     def get_root_path(full_path: str) -> str:

--- a/src/processors/postman_processor.py
+++ b/src/processors/postman_processor.py
@@ -38,10 +38,12 @@ class PostmanProcessor(APIProcessor):
             self.logger.warning("⚠️ No environment variables found in Postman collection")
             env_vars = [{"key": "BASEURL", "value": ""}]
 
-        env_content = "\n".join(f"{var['key']}={var['value']}" for var in env_vars) + "\n"
+        env_content = "\n".join(f"{var['key'].upper()}={var['value']}" for var in env_vars) + "\n"
         file_spec = FileSpec(path=".env", fileContent=env_content)
         self.file_service.create_files(self.config.destination_folder, [file_spec])
-        self.logger.info(f"Generated .env file with variables: {', '.join(var['key'] for var in env_vars)}")
+        self.logger.info(
+            f"Generated .env file with variables: {', '.join(var['key'].upper() for var in env_vars)}"
+        )
 
     def get_api_paths(self, api_definition: APIDefinition) -> List[Dict[str, List[VerbInfo]]]:
         # Get all distinct paths without query params

--- a/src/processors/postman_processor.py
+++ b/src/processors/postman_processor.py
@@ -3,6 +3,8 @@ import json
 import os
 from typing import Dict, List
 
+from ..configuration.config import Config
+
 from .postman.models import VerbInfo, RequestData
 from ..ai_tools.models.file_spec import FileSpec
 from ..models import APIModel, APIVerb, GeneratedModel, ModelInfo, APIDefinition
@@ -15,8 +17,9 @@ from ..utils.logger import Logger
 class PostmanProcessor(APIProcessor):
     """Processes Postman API definitions."""
 
-    def __init__(self, file_service: FileService):
+    def __init__(self, file_service: FileService, config: Config):
         self.file_service = file_service
+        self.config = config
         self.logger = Logger.get_logger(__name__)
         self.service_dict = {}
 
@@ -25,8 +28,19 @@ class PostmanProcessor(APIProcessor):
             data = json.load(f)
         return APIDefinition(PostmanUtils.extract_requests(data))
 
-    def extract_env_vars(self, api_definition: APIDefinition) -> List[str]:
-        return PostmanUtils.extract_env_vars(api_definition)
+    def create_dot_env(self, api_definition: APIDefinition) -> List[str]:
+        self.logger.info("\nGenerating .env file...")
+        env_vars = PostmanUtils.extract_env_vars(api_definition)
+
+        if not env_vars:
+            self.logger.warning("⚠️ No environment variables found in Postman collection")
+            env_vars = ["BASEURL"]
+
+        env_content = "\n".join(f"{var}=" for var in env_vars) + "\n"
+        file_spec = FileSpec(path=".env", fileContent=env_content)
+        self.file_service.create_files(self.config.destination_folder, [file_spec])
+        self.logger.info(f"Generated .env file with variables: {', '.join(env_vars)}")
+        return env_vars
 
     def get_api_paths(self, api_definition: APIDefinition) -> List[Dict[str, List[VerbInfo]]]:
         # Get all distinct paths without query params

--- a/src/processors/swagger_processor.py
+++ b/src/processors/swagger_processor.py
@@ -86,7 +86,7 @@ class SwaggerProcessor(APIProcessor):
             self.logger.error(f"Error processing API definition: {e}")
             raise
 
-    def create_dot_env(self, api_definition: APIDefinition) -> list[str]:
+    def create_dot_env(self, api_definition: APIDefinition) -> None:
         self.logger.info("\nGenerating .env file...")
 
         api_definition_str = api_definition.definitions[0].yaml
@@ -108,7 +108,6 @@ class SwaggerProcessor(APIProcessor):
         self.file_service.create_files(self.config.destination_folder, [file_spec])
 
         self.logger.info(f"Generated .env file with BASEURL={base_url}")
-        return []
 
     @staticmethod
     def _extract_base_url(api_spec):

--- a/src/processors/swagger_processor.py
+++ b/src/processors/swagger_processor.py
@@ -86,7 +86,7 @@ class SwaggerProcessor(APIProcessor):
             self.logger.error(f"Error processing API definition: {e}")
             raise
 
-    def extract_env_vars(self, api_definition: APIDefinition) -> list[str]:
+    def create_dot_env(self, api_definition: APIDefinition) -> list[str]:
         self.logger.info("\nGenerating .env file...")
 
         api_definition_str = api_definition.definitions[0].yaml


### PR DESCRIPTION
## Summary
- rename `extract_env_vars` method to `create_dot_env`
- implement `.env` generation for Postman collections
- inject `Config` into `PostmanProcessor`
- update framework generator and adapters
- Update Postman variable extraction

## Testing
- `black --check src/adapters/processors_adapter.py src/framework_generator.py src/processors/api_processor.py src/processors/postman_processor.py src/processors/swagger_processor.py`
- `python -m py_compile $(git ls-files '*.py')`