### PR TITLE
Add basic pytest infrastructure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-mock pytest-cov
+      - name: Run tests
+        run: pytest --cov=src --cov-report=term

--- a/README.md
+++ b/README.md
@@ -381,6 +381,18 @@ DEBUG=False          # Default: False (INFO level console output)
 LANGCHAIN_DEBUG=False  # Default: False (disabled)
 ```
 
+## Running Tests
+
+Unit and component tests use **pytest**. Install the test dependencies and run `pytest`:
+
+```bash
+pip install -r requirements.txt
+pip install pytest pytest-mock pytest-cov
+pytest
+```
+
+Tests are located in the `tests/` directory. External LLM calls should always be mocked to keep the suite fast and free of API costs.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/docs/follow_up_tasks.md
+++ b/docs/follow_up_tasks.md
@@ -1,0 +1,8 @@
+# Follow-up Testing Tasks
+
+The initial test suite only covers a small portion of the repository. The follow tasks should be created in the project board for complete coverage:
+
+- [ ] Add tests for `LLMService` using mocked language model calls.
+- [ ] Add tests for `CommandService.run_command` and `run_command_with_fix`.
+- [ ] Add tests for API processors (swagger and postman).
+- [ ] Increase coverage for configuration utilities and the dependency injection container.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ dependency-injector~=4.43.0
 black~=24.3.0
 json-repair~=0.35.0
 tabulate>=0.9.0
+pytest~=8.2.2
+pytest-mock~=3.12.0
+pytest-cov~=4.1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from src.configuration.config import Config, Envs
+
+
+@pytest.fixture
+def temp_config(tmp_path):
+    return Config(destination_folder=str(tmp_path), env=Envs.DEV)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,10 @@
+import sys
+from src.configuration.cli import CLIArgumentParser
+
+
+def test_parse_arguments_defaults(monkeypatch):
+    test_args = ["main.py", "spec.yaml"]
+    monkeypatch.setattr(sys, "argv", test_args)
+    args = CLIArgumentParser.parse_arguments()
+    assert args.api_definition == "spec.yaml"
+    assert args.generate == "models_and_tests"

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -1,0 +1,12 @@
+from src.services.command_service import build_typescript_compiler_command
+from src.ai_tools.models.file_spec import FileSpec
+
+
+def test_build_typescript_compiler_command():
+    files = [
+        FileSpec(path="src/a.ts", fileContent=""),
+        FileSpec(path="src/b.ts", fileContent=""),
+    ]
+    cmd = build_typescript_compiler_command(files)
+    assert cmd.startswith("npx tsc src/a.ts src/b.ts")
+    assert "--noEmit" in cmd

--- a/tests/test_file_service.py
+++ b/tests/test_file_service.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from src.services.file_service import FileService
+from src.ai_tools.models.file_spec import FileSpec
+
+
+def test_create_and_read_files(tmp_path):
+    fs = FileService()
+    files = [FileSpec(path="subdir/file.txt", fileContent="hello world")]
+    created = fs.create_files(str(tmp_path), files)
+    expected = tmp_path / "subdir" / "file.txt"
+    assert Path(created[0]) == expected
+    assert expected.exists()
+    content = fs.read_file(str(expected))
+    assert content == "hello world"


### PR DESCRIPTION
## Summary
- install pytest and related packages
- add example unit and integration tests
- provide reusable fixtures
- document how to run tests
- add CI workflow to run pytest
- create follow-up task list for more coverage

## Testing
- `black --check .`
- `pytest -q` *(fails: command not found)*