### PR TITLE
Refactor swagger spec splitting to reuse base spec

### DIFF
--- a/main.py
+++ b/main.py
@@ -101,17 +101,17 @@ def main(
         else:
             framework_generator.restore_state(last_namespace)
 
-        api_definitions = framework_generator.process_api_definition()
+        api_definition = framework_generator.process_api_definition()
 
         if config.list_endpoints:
-            EndpointLister.list_endpoints(api_definitions.definitions)
+            EndpointLister.list_endpoints(api_definition.definitions)
             logger.info("\n✅ Endpoint listing completed successfully!")
         else:
             if not config.use_existing_framework:
-                framework_generator.create_env_file(api_definitions)
-                framework_generator.setup_framework(api_definitions)
+                framework_generator.create_env_file(api_definition)
+                framework_generator.setup_framework(api_definition)
 
-            framework_generator.generate(api_definitions, config.generate)
+            framework_generator.generate(api_definition, config.generate)
             test_files = framework_generator.run_final_checks(config.generate)
 
             logger.info("\n✅ Framework generation completed successfully!")

--- a/src/models/api_definition.py
+++ b/src/models/api_definition.py
@@ -14,6 +14,7 @@ class APIDefinition:
     definitions: List[APIDef | RequestData] = field(default_factory=list)
     endpoints: Optional[List[str]] = None
     variables: List[Dict[str, str]] = field(default_factory=list)
+    base_yaml: Optional[str] = None
 
     def add_definition(self, definition: APIDef) -> None:
         """Add a definition to the list"""
@@ -59,4 +60,5 @@ class APIDefinition:
             "definitions": [d.to_json() for d in self.definitions],
             "endpoints": self.endpoints,
             "variables": self.variables,
+            "base_yaml": self.base_yaml,
         }

--- a/src/processors/swagger/api_definition_merger.py
+++ b/src/processors/swagger/api_definition_merger.py
@@ -26,9 +26,9 @@ class APIDefinitionMerger:
                 else:
                     item_yaml = yaml.safe_load(item.yaml)
                     merged_yaml = yaml.safe_load(merged_definitions[base_path].yaml)
-                    for path, path_data in item_yaml["paths"].items():
-                        if path not in merged_yaml["paths"]:
-                            merged_yaml["paths"].update({path: path_data})
+                    for path, path_data in item_yaml.items():
+                        if path not in merged_yaml:
+                            merged_yaml.update({path: path_data})
                     merged_definitions[base_path].yaml = yaml.dump(merged_yaml, sort_keys=False)
             elif isinstance(item, APIVerb):
                 merged_definitions[f"{item.path}-{item.verb}"] = copy.deepcopy(item)

--- a/tests/unit/processors/swagger/test_swagger_merger.py
+++ b/tests/unit/processors/swagger/test_swagger_merger.py
@@ -2,20 +2,15 @@ import yaml  # noqa: F401
 
 from src.processors.swagger import APIDefinitionMerger
 from src.models import APIPath, APIVerb
+import yaml
 
 
 def test_merger_merge_two_differente_paths():
     merger = APIDefinitionMerger()
 
-    sample_yaml_str = """openapi: 3.0.0
-info:
-  title: Test API
-  version: '1.0'
-paths:
-  /api/v1/path:
-    get:
-      description: path details
-"""
+    sample_yaml_str = yaml.dump(
+        {"/api/v1/path": {"get": {"description": "path details"}}}, sort_keys=False
+    )
 
     parts_to_merge = [
         APIPath(path="/users/{id}", yaml=sample_yaml_str),
@@ -35,34 +30,28 @@ paths:
     assert len(merged_api_verbs) == 2
 
     assert merged_api_paths[0].path == "/users"
-    assert merged_api_paths[0].yaml == sample_yaml_str
+    assert yaml.safe_load(merged_api_paths[0].yaml) == yaml.safe_load(sample_yaml_str)
     assert merged_api_paths[0].type == "path"
 
     assert merged_api_verbs[0].path == "/users/{id}"
     assert merged_api_verbs[0].verb == "GET"
     assert merged_api_verbs[0].root_path == "/users"
-    assert merged_api_verbs[0].yaml == sample_yaml_str
+    assert yaml.safe_load(merged_api_verbs[0].yaml) == yaml.safe_load(sample_yaml_str)
     assert merged_api_verbs[0].type == "verb"
 
     assert merged_api_verbs[1].path == "/users"  # This was originally /users for POST
     assert merged_api_verbs[1].verb == "POST"
     assert merged_api_verbs[1].root_path == "/users"
-    assert merged_api_verbs[1].yaml == sample_yaml_str
+    assert yaml.safe_load(merged_api_verbs[1].yaml) == yaml.safe_load(sample_yaml_str)
     assert merged_api_verbs[1].type == "verb"
 
 
 def test_merger_merge_two_equal_paths():
     merger = APIDefinitionMerger()
 
-    sample_yaml_str = """openapi: 3.0.0
-info:
-  title: Test API
-  version: '1.0'
-paths:
-  /api/v1/users:
-    get:
-      description: user details
-"""
+    sample_yaml_str = yaml.dump(
+        {"/api/v1/users": {"get": {"description": "user details"}}}, sort_keys=False
+    )
 
     parts_to_merge = [
         APIPath(path="/users", yaml=sample_yaml_str),
@@ -91,15 +80,9 @@ paths:
 def test_merger_merge_four_paths_into_two():
     merger = APIDefinitionMerger()
 
-    sample_yaml_str = """openapi: 3.0.0
-info:
-  title: Test API
-  version: '1.0'
-paths:
-  /api/v1/users:
-    get:
-      description: user details
-"""
+    sample_yaml_str = yaml.dump(
+        {"/api/v1/users": {"get": {"description": "user details"}}}, sort_keys=False
+    )
 
     parts_to_merge = [
         APIPath(path="/users/{id}", yaml=sample_yaml_str),
@@ -129,42 +112,18 @@ paths:
 def test_merger_yaml_content_preserved():
     merger = APIDefinitionMerger()
 
-    path_users_details_yaml_str = """openapi: 3.0.0
-info:
-  title: Test API
-  version: '1.0'
-paths:
-  /api/v1/users/{id}:
-    get:
-      description: user details
-"""
-    path_users_list_yaml_str = """openapi: 3.0.0
-info:
-  title: Test API
-  version: '1.0'
-paths:
-  /api/v1/users:
-    post:
-      description: create user
-"""
-    verb_users_get_yaml_str = """openapi: 3.0.0
-info:
-  title: Test API
-  version: '1.0'
-paths:
-  /api/v1/users/{id}:
-    get:
-      description: user details
-"""
-    verb_users_post_yaml_str = """openapi: 3.0.0
-info:
-  title: Test API
-  version: '1.0'
-paths:
-  /api/v1/users:
-    post:
-      description: create user
-"""
+    path_users_details_yaml_str = yaml.dump(
+        {"/api/v1/users/{id}": {"get": {"description": "user details"}}}, sort_keys=False
+    )
+    path_users_list_yaml_str = yaml.dump(
+        {"/api/v1/users": {"post": {"description": "create user"}}}, sort_keys=False
+    )
+    verb_users_get_yaml_str = yaml.dump(
+        {"/api/v1/users/{id}": {"get": {"description": "user details"}}}, sort_keys=False
+    )
+    verb_users_post_yaml_str = yaml.dump(
+        {"/api/v1/users": {"post": {"description": "create user"}}}, sort_keys=False
+    )
 
     parts_to_merge = [
         APIPath(path="/users/{id}", yaml=path_users_details_yaml_str),
@@ -188,20 +147,20 @@ paths:
     users_path_obj = merged_api_paths[0]
     users_path_yaml_content = yaml.safe_load(users_path_obj.yaml)
 
-    assert "/api/v1/users/{id}" in users_path_yaml_content["paths"]
-    assert "/api/v1/users" in users_path_yaml_content["paths"]
-    assert len(users_path_yaml_content["paths"]) == 2
-    assert users_path_yaml_content["paths"]["/api/v1/users/{id}"]["get"]["description"] == "user details"
-    assert users_path_yaml_content["paths"]["/api/v1/users"]["post"]["description"] == "create user"
+    assert "/api/v1/users/{id}" in users_path_yaml_content
+    assert "/api/v1/users" in users_path_yaml_content
+    assert len(users_path_yaml_content) == 2
+    assert users_path_yaml_content["/api/v1/users/{id}"]["get"]["description"] == "user details"
+    assert users_path_yaml_content["/api/v1/users"]["post"]["description"] == "create user"
 
     assert merged_api_verbs[0].path == "/users"
     assert merged_api_verbs[0].verb == "POST"
     assert merged_api_verbs[0].root_path == "/users"
     users_post_verb_yaml = yaml.safe_load(merged_api_verbs[0].yaml)
-    assert users_post_verb_yaml["paths"]["/api/v1/users"]["post"]["description"] == "create user"
+    assert users_post_verb_yaml["/api/v1/users"]["post"]["description"] == "create user"
 
     assert merged_api_verbs[1].path == "/users/{id}"
     assert merged_api_verbs[1].verb == "GET"
     assert merged_api_verbs[1].root_path == "/users"
     users_get_verb_yaml = yaml.safe_load(merged_api_verbs[1].yaml)
-    assert users_get_verb_yaml["paths"]["/api/v1/users/{id}"]["get"]["description"] == "user details"
+    assert users_get_verb_yaml["/api/v1/users/{id}"]["get"]["description"] == "user details"

--- a/tests/unit/processors/swagger/test_swagger_merger.py
+++ b/tests/unit/processors/swagger/test_swagger_merger.py
@@ -1,5 +1,3 @@
-import yaml  # noqa: F401
-
 from src.processors.swagger import APIDefinitionMerger
 from src.models import APIPath, APIVerb
 import yaml
@@ -8,9 +6,7 @@ import yaml
 def test_merger_merge_two_differente_paths():
     merger = APIDefinitionMerger()
 
-    sample_yaml_str = yaml.dump(
-        {"/api/v1/path": {"get": {"description": "path details"}}}, sort_keys=False
-    )
+    sample_yaml_str = yaml.dump({"/api/v1/path": {"get": {"description": "path details"}}}, sort_keys=False)
 
     parts_to_merge = [
         APIPath(path="/users/{id}", yaml=sample_yaml_str),
@@ -39,7 +35,7 @@ def test_merger_merge_two_differente_paths():
     assert yaml.safe_load(merged_api_verbs[0].yaml) == yaml.safe_load(sample_yaml_str)
     assert merged_api_verbs[0].type == "verb"
 
-    assert merged_api_verbs[1].path == "/users"  # This was originally /users for POST
+    assert merged_api_verbs[1].path == "/users"
     assert merged_api_verbs[1].verb == "POST"
     assert merged_api_verbs[1].root_path == "/users"
     assert yaml.safe_load(merged_api_verbs[1].yaml) == yaml.safe_load(sample_yaml_str)
@@ -49,9 +45,7 @@ def test_merger_merge_two_differente_paths():
 def test_merger_merge_two_equal_paths():
     merger = APIDefinitionMerger()
 
-    sample_yaml_str = yaml.dump(
-        {"/api/v1/users": {"get": {"description": "user details"}}}, sort_keys=False
-    )
+    sample_yaml_str = yaml.dump({"/api/v1/users": {"get": {"description": "user details"}}}, sort_keys=False)
 
     parts_to_merge = [
         APIPath(path="/users", yaml=sample_yaml_str),
@@ -80,9 +74,7 @@ def test_merger_merge_two_equal_paths():
 def test_merger_merge_four_paths_into_two():
     merger = APIDefinitionMerger()
 
-    sample_yaml_str = yaml.dump(
-        {"/api/v1/users": {"get": {"description": "user details"}}}, sort_keys=False
-    )
+    sample_yaml_str = yaml.dump({"/api/v1/users": {"get": {"description": "user details"}}}, sort_keys=False)
 
     parts_to_merge = [
         APIPath(path="/users/{id}", yaml=sample_yaml_str),

--- a/tests/unit/processors/swagger/test_swagger_processor.py
+++ b/tests/unit/processors/swagger/test_swagger_processor.py
@@ -1,0 +1,39 @@
+import yaml
+from src.processors.swagger import APIDefinitionSplitter, APIDefinitionMerger
+from src.processors.swagger_processor import SwaggerProcessor
+from src.services.file_service import FileService
+from src.configuration.config import Config
+from src.models import APIPath, APIVerb
+
+
+def test_swagger_processor_rebuilds_full_definition():
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Test", "version": "1.0"},
+        "paths": {
+            "/api/v1/items": {
+                "get": {"responses": {"200": {"description": "ok"}}}
+            }
+        },
+    }
+
+    splitter = APIDefinitionSplitter()
+    base_yaml, parts = splitter.split(spec)
+    merger = APIDefinitionMerger()
+    merged = merger.merge(parts)
+
+    processor = SwaggerProcessor(
+        file_loader=FileService(),
+        splitter=splitter,
+        merger=merger,
+        file_service=FileService(),
+        config=Config(),
+    )
+    processor.base_yaml = base_yaml
+
+    api_path = next(p for p in merged if isinstance(p, APIPath))
+    full_yaml = processor.get_api_path_content(api_path)
+    reconstructed = yaml.safe_load(full_yaml)
+
+    assert reconstructed["openapi"] == "3.0.0"
+    assert "/api/v1/items" in reconstructed["paths"]

--- a/tests/unit/processors/swagger/test_swagger_processor.py
+++ b/tests/unit/processors/swagger/test_swagger_processor.py
@@ -6,13 +6,18 @@ from src.configuration.config import Config
 from src.models import APIPath, APIVerb
 
 
-def test_swagger_processor_rebuilds_full_definition():
+def test_swagger_processor_rebuilds_full_path_definition():
     spec = {
         "openapi": "3.0.0",
         "info": {"title": "Test", "version": "1.0"},
-        "paths": {
-            "/api/v1/items": {
-                "get": {"responses": {"200": {"description": "ok"}}}
+        "paths": {"/api/v1/items": {"get": {"responses": {"200": {"description": "ok"}}}}},
+        "servers": [{"url": "https://api.example.com"}],
+        "components": {
+            "schemas": {
+                "Item": {
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}, "name": {"type": "string"}},
+                }
             }
         },
     }
@@ -29,11 +34,54 @@ def test_swagger_processor_rebuilds_full_definition():
         file_service=FileService(),
         config=Config(),
     )
-    processor.base_yaml = base_yaml
+    processor.base_definition = base_yaml
 
     api_path = next(p for p in merged if isinstance(p, APIPath))
     full_yaml = processor.get_api_path_content(api_path)
     reconstructed = yaml.safe_load(full_yaml)
 
-    assert reconstructed["openapi"] == "3.0.0"
+    assert "/api/v1/items" not in base_yaml
     assert "/api/v1/items" in reconstructed["paths"]
+
+    assert "https://api.example.com" not in api_path.yaml
+    assert reconstructed["openapi"] == "3.0.0"
+    assert reconstructed["servers"] == [{"url": "https://api.example.com"}]
+    assert reconstructed["components"]["schemas"]["Item"] == {
+        "type": "object",
+        "properties": {"id": {"type": "string"}, "name": {"type": "string"}},
+    }
+
+
+def test_swagger_processor_rebuilds_full_verb_definition():
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Test", "version": "1.0"},
+        "paths": {"/api/v1/items": {"get": {"responses": {"200": {"description": "ok"}}}}},
+        "servers": [{"url": "https://api.example.com"}],
+    }
+
+    splitter = APIDefinitionSplitter()
+    base_yaml, parts = splitter.split(spec)
+    merger = APIDefinitionMerger()
+    merged = merger.merge(parts)
+
+    processor = SwaggerProcessor(
+        file_loader=FileService(),
+        splitter=splitter,
+        merger=merger,
+        file_service=FileService(),
+        config=Config(),
+    )
+    processor.base_definition = base_yaml
+
+    api_verb = next(p for p in merged if isinstance(p, APIVerb))
+    full_yaml = processor.get_api_verb_content(api_verb)
+    reconstructed = yaml.safe_load(full_yaml)
+
+    assert "/api/v1/items" not in base_yaml
+    assert "/api/v1/items" in reconstructed["paths"]
+    assert "get" in reconstructed["paths"]["/api/v1/items"]
+
+    assert "https://api.example.com" not in api_verb.yaml
+    assert reconstructed["openapi"] == "3.0.0"
+    assert reconstructed["servers"] == [{"url": "https://api.example.com"}]

--- a/tests/unit/processors/swagger/test_swagger_splitter.py
+++ b/tests/unit/processors/swagger/test_swagger_splitter.py
@@ -51,6 +51,11 @@ def test_splitter_on_populated_openapi_spec():
     assert sum(isinstance(p, APIPath) for p in parts) == 1
     assert sum(isinstance(p, APIVerb) for p in parts) == 2
 
+    assert "/api/v1/users" not in base_yaml
+    assert base_yaml["openapi"] == "3.0.0"
+    assert base_yaml["info"]["title"] == "Title"
+    assert base_yaml["servers"] == [{"url": "http://localhost:3000", "description": "Local server"}]
+
 
 def test_splitter_empty_paths():
     spec = {"paths": {}}

--- a/tests/unit/processors/swagger/test_swagger_splitter.py
+++ b/tests/unit/processors/swagger/test_swagger_splitter.py
@@ -52,9 +52,10 @@ def test_splitter_on_populated_openapi_spec():
     assert sum(isinstance(p, APIVerb) for p in parts) == 2
 
     assert "/api/v1/users" not in base_yaml
-    assert base_yaml["openapi"] == "3.0.0"
-    assert base_yaml["info"]["title"] == "Title"
-    assert base_yaml["servers"] == [{"url": "http://localhost:3000", "description": "Local server"}]
+    base_yaml_dict = yaml.safe_load(base_yaml)
+    assert base_yaml_dict["openapi"] == "3.0.0"
+    assert base_yaml_dict["info"]["title"] == "Title"
+    assert base_yaml_dict["servers"] == [{"url": "http://localhost:3000", "description": "Local server"}]
 
 
 def test_splitter_empty_paths():


### PR DESCRIPTION
## Summary
- avoid duplicating spec metadata when splitting swagger definitions
- store base YAML once in `APIDefinition`
- update splitter/merger to handle only path data
- reconstruct full spec on demand in `SwaggerProcessor`
- adjust existing swagger tests and add processor test