### PR TITLE
119 improve api definition processing pt2

### DIFF
--- a/src/adapters/processors_adapter.py
+++ b/src/adapters/processors_adapter.py
@@ -5,6 +5,7 @@ from ..processors.swagger import (
     APIDefinitionMerger,
     APIDefinitionSplitter,
     FileLoader,
+    APIComponentsFilter,
 )
 from ..processors.swagger_processor import SwaggerProcessor
 from ..services.file_service import FileService
@@ -20,12 +21,14 @@ class ProcessorsAdapter(containers.DeclarativeContainer):
     file_loader = providers.Factory(FileLoader)
     splitter = providers.Factory(APIDefinitionSplitter)
     merger = providers.Factory(APIDefinitionMerger)
+    components_filter = providers.Factory(APIComponentsFilter)
 
     swagger_processor = providers.Factory(
         SwaggerProcessor,
         file_loader=file_loader,
         splitter=splitter,
         merger=merger,
+        components_filter=components_filter,
         file_service=file_service,
         config=config,
     )

--- a/src/processors/swagger/__init__.py
+++ b/src/processors/swagger/__init__.py
@@ -2,10 +2,12 @@ from .api_definition_loader import APIDefinitionLoader
 from .api_definition_merger import APIDefinitionMerger
 from .api_definition_splitter import APIDefinitionSplitter
 from .file_handler import FileLoader
+from .api_components_filter import APIComponentsFilter
 
 __all__ = [
     "APIDefinitionMerger",
     "APIDefinitionSplitter",
     "FileLoader",
     "APIDefinitionLoader",
+    "APIComponentsFilter",
 ]

--- a/src/processors/swagger/api_components_filter.py
+++ b/src/processors/swagger/api_components_filter.py
@@ -1,0 +1,60 @@
+import copy
+from typing import Dict, List, Any
+
+from ...utils.logger import Logger
+
+
+class APIComponentsFilter:
+    """Reduces API definition components to only those that are necessary."""
+
+    def __init__(self):
+        self.logger = Logger.get_logger(__name__)
+
+    def filter_schemas(self, api_definition: Dict[str, Any]) -> Dict[str, Any]:
+        """Filters out unreferenced schemas from the API definition components."""
+        filtered_spec = copy.deepcopy(api_definition)
+
+        if "components" not in filtered_spec:
+            self.logger.info("No components found in the API definition.")
+            return filtered_spec
+        components = filtered_spec.get("components", {})
+
+        used_refs = self.collect_refs(filtered_spec.get("paths", {}))
+        if "schemas" not in components:
+            self.logger.info("No schemas found in the components.")
+            return filtered_spec
+
+        self.logger.info("Filtering schemas from components...")
+        filtered_schemas = self.collect_used_schemas(components.get("schemas", {}), used_refs)
+
+        # TODO: Create a method to handle this separately.
+        for component_name, component_data in components.items():
+            if component_name != "schemas":
+                filtered_spec["components"][component_name] = component_data
+
+        filtered_spec["components"]["schemas"] = filtered_schemas
+        self.logger.info("Successfully filtered schemas.")
+        return filtered_spec
+
+    def collect_refs(self, node: Any, refs: List[str] = None) -> List[str]:
+        """Recursively collects all $ref in the API paths."""
+        if refs is None:
+            refs = []
+
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == "$ref":
+                    refs.append(value)
+                else:
+                    self.collect_refs(value, refs)
+        return refs
+
+    def collect_used_schemas(self, schemas: Dict[str, Any], used_refs: List[str]) -> Dict[str, Any]:
+        """Returns only the referenced schemas."""
+        collected_schemas = {}
+
+        for schema_name, schema in schemas.items():
+            ref_string = f"#/components/schemas/{schema_name}"
+            if ref_string in used_refs:
+                collected_schemas[schema_name] = schema
+        return collected_schemas

--- a/src/processors/swagger_processor.py
+++ b/src/processors/swagger_processor.py
@@ -7,6 +7,7 @@ from .swagger import (
     APIDefinitionMerger,
     APIDefinitionSplitter,
     APIDefinitionLoader,
+    APIComponentsFilter,
 )
 from ..ai_tools.models.file_spec import FileSpec
 from ..configuration.config import Config
@@ -24,6 +25,7 @@ class SwaggerProcessor(APIProcessor):
         file_loader: FileService,
         splitter: APIDefinitionSplitter,
         merger: APIDefinitionMerger,
+        components_filter: APIComponentsFilter,
         file_service: FileService,
         config: Config,
         api_definition_loader: Optional[APIDefinitionLoader] = None,
@@ -35,6 +37,7 @@ class SwaggerProcessor(APIProcessor):
             file_loader (FileLoader): Service to load API definition files.
             splitter (APIDefinitionSplitter): Service to split API definitions.
             merger (APIDefinitionMerger): Service to merge API definitions.
+            components_filter (APIComponentsFilter): Service to filter API components.
             api_definition_loader (APIDefinitionLoader): Service to load API definition from URL or file.
         """
         self.config = config
@@ -42,6 +45,7 @@ class SwaggerProcessor(APIProcessor):
         self.file_loader = file_loader
         self.splitter = splitter
         self.merger = merger
+        self.components_filter = components_filter
         self.api_definition_loader = api_definition_loader or APIDefinitionLoader()
         self.base_definition: str | None = None
         self.logger = Logger.get_logger(__name__)
@@ -180,4 +184,5 @@ class SwaggerProcessor(APIProcessor):
         base_spec = yaml.safe_load(self.base_definition or "{}")
         paths_spec = yaml.safe_load(paths_yaml or "{}")
         base_spec["paths"] = paths_spec
-        return yaml.dump(base_spec, sort_keys=False)
+        filtered_spec = self.components_filter.filter_schemas(base_spec)
+        return yaml.dump(filtered_spec, sort_keys=False)

--- a/tests/unit/processors/swagger/test_swagger_component_filter.py
+++ b/tests/unit/processors/swagger/test_swagger_component_filter.py
@@ -1,0 +1,405 @@
+from src.processors.swagger import APIComponentsFilter
+
+
+def test_filter_on_used_schemas():
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "paths": {
+            "/items/{id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "A single item",
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/Item"}}
+                            },
+                        }
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {"type": "object", "properties": {"id": {"type": "integer"}}},
+            }
+        },
+    }
+
+    components_filter = APIComponentsFilter()
+    filtered_yaml_dict = components_filter.filter_schemas(spec)
+
+    assert "components" in filtered_yaml_dict
+    assert "schemas" in filtered_yaml_dict["components"]
+
+    assert filtered_yaml_dict["components"]["schemas"]["Item"] == {
+        "type": "object",
+        "properties": {"id": {"type": "integer"}},
+    }
+
+
+def test_filter_on_unused_schemas():
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "paths": {
+            "/items/{id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "A single item",
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/Item"}}
+                            },
+                        }
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {"type": "object", "properties": {"id": {"type": "integer"}}},
+                "UnusedSchema": {"type": "object", "properties": {"name": {"type": "string"}}},
+            }
+        },
+    }
+
+    components_filter = APIComponentsFilter()
+    filtered_yaml_dict = components_filter.filter_schemas(spec)
+
+    assert "components" in filtered_yaml_dict
+    assert "schemas" in filtered_yaml_dict["components"]
+    assert "Item" in filtered_yaml_dict["components"]["schemas"]
+    assert "UnusedSchema" not in filtered_yaml_dict["components"]["schemas"]
+
+
+def test_filter_on_multiple_used_schemas():
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "paths": {
+            "/items/{id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "A single item",
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/Item"}}
+                            },
+                        }
+                    }
+                }
+            },
+            "/items2/{id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "A single item",
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/Item2"}}
+                            },
+                        }
+                    }
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Item": {"type": "object", "properties": {"id": {"type": "integer"}}},
+                "Item2": {"type": "object", "properties": {"id": {"type": "string"}}},
+            }
+        },
+    }
+
+    components_filter = APIComponentsFilter()
+    filtered_yaml_dict = components_filter.filter_schemas(spec)
+
+    assert "components" in filtered_yaml_dict
+    assert "schemas" in filtered_yaml_dict["components"]
+    assert "Item" in filtered_yaml_dict["components"]["schemas"]
+    assert "Item2" in filtered_yaml_dict["components"]["schemas"]
+
+
+def test_filter_on_multiple_unused_schemas():
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "paths": {
+            "/items/{id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "A single item",
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/Item"}}
+                            },
+                        }
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {"type": "object", "properties": {"id": {"type": "integer"}}},
+                "UnusedSchema": {"type": "object", "properties": {"name": {"type": "string"}}},
+                "UnusedSchema2": {"type": "object", "properties": {"name": {"type": "string"}}},
+            }
+        },
+    }
+
+    components_filter = APIComponentsFilter()
+    filtered_yaml_dict = components_filter.filter_schemas(spec)
+
+    assert "components" in filtered_yaml_dict
+    assert "schemas" in filtered_yaml_dict["components"]
+    assert "Item" in filtered_yaml_dict["components"]["schemas"]
+    assert "UnusedSchema" not in filtered_yaml_dict["components"]["schemas"]
+    assert "UnusedSchema2" not in filtered_yaml_dict["components"]["schemas"]
+
+
+def test_filter_on_multiple_used_and_unused_schemas():
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "paths": {
+            "/items/{id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "A single item",
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/Item"}}
+                            },
+                        }
+                    }
+                }
+            },
+            "/items2/{id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "A single item",
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/Item2"}}
+                            },
+                        }
+                    }
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Item": {"type": "object", "properties": {"id": {"type": "integer"}}},
+                "Item2": {"type": "object", "properties": {"id": {"type": "string"}}},
+                "UnusedSchema": {"type": "object", "properties": {"name": {"type": "string"}}},
+                "UnusedSchema2": {"type": "object", "properties": {"name": {"type": "string"}}},
+            }
+        },
+    }
+
+    components_filter = APIComponentsFilter()
+    filtered_yaml_dict = components_filter.filter_schemas(spec)
+
+    assert "components" in filtered_yaml_dict
+    assert "schemas" in filtered_yaml_dict["components"]
+    assert "Item" in filtered_yaml_dict["components"]["schemas"]
+    assert "Item2" in filtered_yaml_dict["components"]["schemas"]
+    assert "UnusedSchema" not in filtered_yaml_dict["components"]["schemas"]
+    assert "UnusedSchema2" not in filtered_yaml_dict["components"]["schemas"]
+
+
+def test_filter_on_duplicated_schema_refs():
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "paths": {
+            "/items": {
+                "get": {
+                    "summary": "Get all items",
+                    "responses": {
+                        "200": {
+                            "description": "A list of items",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/Item"},
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "servers": [{"url": "https://api.example.com"}],
+            "/items/{id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "A single item",
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/Item"}}
+                            },
+                        }
+                    }
+                }
+            },
+        },
+        "servers": [{"url": "https://api.example.com"}],
+        "components": {
+            "schemas": {
+                "Item": {"type": "object", "properties": {"id": {"type": "integer"}}},
+                "Item2": {"type": "object", "properties": {"id": {"type": "string"}}},
+                "UnusedSchema": {"type": "object", "properties": {"name": {"type": "string"}}},
+            }
+        },
+    }
+
+    components_filter = APIComponentsFilter()
+    filtered_yaml_dict = components_filter.filter_schemas(spec)
+
+    assert "components" in filtered_yaml_dict
+    assert "schemas" in filtered_yaml_dict["components"]
+    assert "Item" in filtered_yaml_dict["components"]["schemas"]
+    assert len(filtered_yaml_dict["components"]["schemas"]) == 1
+    assert "UnusedSchema" not in filtered_yaml_dict["components"]["schemas"]
+
+
+def test_filter_schemas_on_multiple_components():
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "paths": {
+            "/items/{id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "A single item",
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/Item"}}
+                            },
+                        }
+                    }
+                }
+            }
+        },
+        "servers": [{"url": "https://api.example.com"}],
+        "components": {
+            "schemas": {
+                "Item": {"type": "object", "properties": {"id": {"type": "integer"}}},
+                "UnusedSchema": {"type": "object", "properties": {"name": {"type": "string"}}},
+            },
+            "parameters": {
+                "IdParam": {"name": "id", "in": "path", "required": True, "schema": {"type": "string"}}
+            },
+            "securitySchemes": {
+                "ApiKeyAuth": {
+                    "type": "apiKey",
+                    "in": "header",
+                    "name": "X-API-Key",
+                }
+            },
+        },
+    }
+
+    components_filter = APIComponentsFilter()
+    filtered_yaml_dict = components_filter.filter_schemas(spec)
+
+    expected_filtered_spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "paths": {
+            "/items/{id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "A single item",
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/Item"}}
+                            },
+                        }
+                    }
+                }
+            }
+        },
+        "servers": [{"url": "https://api.example.com"}],
+        "components": {
+            "schemas": {
+                "Item": {"type": "object", "properties": {"id": {"type": "integer"}}},
+            },
+            "parameters": {
+                "IdParam": {"name": "id", "in": "path", "required": True, "schema": {"type": "string"}}
+            },
+            "securitySchemes": {
+                "ApiKeyAuth": {
+                    "type": "apiKey",
+                    "in": "header",
+                    "name": "X-API-Key",
+                }
+            },
+        },
+    }
+    assert filtered_yaml_dict == expected_filtered_spec
+
+
+# def test_filter_on_duplicated_schema():
+#     assert False, "This test is not implemented yet"
+
+
+def test_filter_on_no_schemas():
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "paths": {
+            "/items/{id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "A single item",
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/Item"}}
+                            },
+                        }
+                    }
+                }
+            }
+        },
+        "servers": [{"url": "https://api.example.com"}],
+        "components": {},
+    }
+
+    components_filter = APIComponentsFilter()
+    filtered_yaml_dict = components_filter.filter_schemas(spec)
+
+    assert filtered_yaml_dict == spec
+
+
+def test_filter_on_no_components():
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "paths": {
+            "/items/{id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "A single item",
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/Item"}}
+                            },
+                        }
+                    }
+                }
+            }
+        },
+        "servers": [{"url": "https://api.example.com"}],
+    }
+
+    components_filter = APIComponentsFilter()
+    filtered_yaml_dict = components_filter.filter_schemas(spec)
+
+    assert filtered_yaml_dict == spec
+
+
+# def test_filter_on_empty_spec():
+#     assert False, "This test is not implemented yet"

--- a/tests/unit/processors/swagger/test_swagger_processor.py
+++ b/tests/unit/processors/swagger/test_swagger_processor.py
@@ -1,5 +1,5 @@
 import yaml
-from src.processors.swagger import APIDefinitionSplitter, APIDefinitionMerger
+from src.processors.swagger import APIDefinitionSplitter, APIDefinitionMerger, APIComponentsFilter
 from src.processors.swagger_processor import SwaggerProcessor
 from src.services.file_service import FileService
 from src.configuration.config import Config
@@ -10,7 +10,20 @@ def test_swagger_processor_rebuilds_full_path_definition():
     spec = {
         "openapi": "3.0.0",
         "info": {"title": "Test", "version": "1.0"},
-        "paths": {"/api/v1/items": {"get": {"responses": {"200": {"description": "ok"}}}}},
+        "paths": {
+            "/api/v1/items": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "ok",
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/Item"}}
+                            },
+                        }
+                    }
+                }
+            }
+        },
         "servers": [{"url": "https://api.example.com"}],
         "components": {
             "schemas": {
@@ -26,11 +39,13 @@ def test_swagger_processor_rebuilds_full_path_definition():
     base_yaml, parts = splitter.split(spec)
     merger = APIDefinitionMerger()
     merged = merger.merge(parts)
+    components_filter = APIComponentsFilter()
 
     processor = SwaggerProcessor(
         file_loader=FileService(),
         splitter=splitter,
         merger=merger,
+        components_filter=components_filter,
         file_service=FileService(),
         config=Config(),
     )
@@ -64,11 +79,13 @@ def test_swagger_processor_rebuilds_full_verb_definition():
     base_yaml, parts = splitter.split(spec)
     merger = APIDefinitionMerger()
     merged = merger.merge(parts)
+    components_filter = APIComponentsFilter()
 
     processor = SwaggerProcessor(
         file_loader=FileService(),
         splitter=splitter,
         merger=merger,
+        components_filter=components_filter,
         file_service=FileService(),
         config=Config(),
     )


### PR DESCRIPTION
- Add components filter for schemas
- Add multiple tests for the filter_schemas
- Insert the filter into the swagger_processor/_build_full_definition function

Reference to task:
[](https://github.com/TestCraft-App/api-automation-agent/issues/119)
