### PR TITLE
Add benchmark for comparing generated tests to ground truth

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -123,3 +123,24 @@ By comparing these metrics across different LLMs, you can gain insights into the
 *   **Dependency Issues**: Double-check that all Python and Node.js dependencies are installed.
 *   **File Path Errors**: Verify that the path to your OpenAPI specification is correct.
 *   **TypeScript Compilation Errors**: If many files are skipped, it might point to systemic issues in how an LLM generates code. Review the generated files in the output directory for that LLM. 
+## Test Coverage Benchmark
+
+The `coverage_benchmark.py` utility evaluates how closely a generated test framework matches a list of ideal tests. Ground truth data lives in YAML or JSON files under `benchmarks/test_coverage/ground_truths`.
+
+To see available ground truth specifications and their endpoints:
+
+```bash
+python benchmarks/test_coverage/coverage_benchmark.py list
+```
+
+To run the benchmark for a specific endpoint and HTTP verb:
+
+```bash
+python benchmarks/test_coverage/coverage_benchmark.py run \
+    --ground-truth benchmarks/test_coverage/ground_truths/sample.yaml \
+    --framework-path <path_to_generated_framework> \
+    --endpoint /user \
+    --verb get
+```
+
+The output shows the percentage of ideal tests covered and any extra tests that were generated but not listed in the ground truth.

--- a/benchmarks/test_coverage/coverage_benchmark.py
+++ b/benchmarks/test_coverage/coverage_benchmark.py
@@ -1,0 +1,97 @@
+import argparse
+import json
+import os
+import re
+import yaml
+from typing import Dict, List
+
+GROUND_TRUTHS_DIR = os.path.join(os.path.dirname(__file__), "ground_truths")
+
+
+def load_ground_truth(path: str) -> Dict:
+    with open(path, "r") as f:
+        if path.endswith((".yml", ".yaml")):
+            return yaml.safe_load(f)
+        return json.load(f)
+
+
+def list_available_ground_truths(directory: str = GROUND_TRUTHS_DIR) -> List[Dict]:
+    ground_truths = []
+    if not os.path.isdir(directory):
+        return ground_truths
+    for file in os.listdir(directory):
+        if file.endswith((".yml", ".yaml", ".json")):
+            data = load_ground_truth(os.path.join(directory, file))
+            ground_truths.append(
+                {"file": file, "spec": data.get("spec"), "endpoints": list(data.get("endpoints", {}).keys())}
+            )
+    return ground_truths
+
+
+def sanitize_endpoint(endpoint: str) -> str:
+    return endpoint.strip("/").replace("/", "_").replace("{", "").replace("}", "")
+
+
+def parse_test_file(path: str) -> List[str]:
+    with open(path, "r") as f:
+        content = f.read()
+    suite_match = re.search(r"describe\(\s*[\"']([^\"']+)[\"']", content)
+    suite = suite_match.group(1) if suite_match else "Unknown Suite"
+    tests = re.findall(r"it\(\s*[\"']([^\"']+)[\"']", content)
+    return [f"{suite}::{t}" for t in tests]
+
+
+def collect_tests(framework_path: str, endpoint: str, verb: str) -> List[str]:
+    tests_path = os.path.join(framework_path, "src", "tests", sanitize_endpoint(endpoint))
+    pattern = f"{verb.upper()}-*.spec.ts"
+    collected: List[str] = []
+    if not os.path.isdir(tests_path):
+        return collected
+    for file in os.listdir(tests_path):
+        if re.fullmatch(pattern.replace("*", ".*"), file):
+            collected.extend(parse_test_file(os.path.join(tests_path, file)))
+    return collected
+
+
+def calculate_coverage(ground_truth_tests: List[str], actual_tests: List[str]) -> Dict:
+    gt_set = set(ground_truth_tests)
+    actual_set = set(actual_tests)
+    matched = gt_set & actual_set
+    extra = actual_set - gt_set
+    coverage = round(len(matched) / len(gt_set) * 100, 2) if gt_set else 0.0
+    return {"coverage_percent": coverage, "extra_tests": sorted(extra), "matched_tests": sorted(matched)}
+
+
+def run(args: argparse.Namespace):
+    if args.command == "list":
+        for item in list_available_ground_truths():
+            print(f"{item['file']}: spec={item['spec']}, endpoints={', '.join(item['endpoints'])}")
+        return
+
+    data = load_ground_truth(args.ground_truth)
+    endpoint_data = data.get("endpoints", {}).get(args.endpoint, {})
+    gt_tests = endpoint_data.get(args.verb.lower(), [])
+    actual_tests = collect_tests(args.framework_path, args.endpoint, args.verb)
+    results = calculate_coverage(gt_tests, actual_tests)
+    print(json.dumps(results, indent=2))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Test Coverage Benchmark")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("list", help="List available ground truths")
+
+    run_parser = sub.add_parser("run", help="Run coverage benchmark")
+    run_parser.add_argument("--ground-truth", required=True, help="Path to ground truth YAML/JSON")
+    run_parser.add_argument("--framework-path", required=True, help="Path to generated framework root")
+    run_parser.add_argument("--endpoint", required=True, help="Endpoint to evaluate")
+    run_parser.add_argument("--verb", required=True, help="HTTP verb to evaluate")
+
+    return parser
+
+
+if __name__ == "__main__":
+    parser = build_parser()
+    args = parser.parse_args()
+    run(args)

--- a/benchmarks/test_coverage/ground_truths/sample.yaml
+++ b/benchmarks/test_coverage/ground_truths/sample.yaml
@@ -1,0 +1,7 @@
+spec: sample
+endpoints:
+  /user:
+    get:
+      - "User Suite::should get user"
+    post:
+      - "User Suite::should create user"

--- a/tests/unit/benchmarks/test_coverage_benchmark.py
+++ b/tests/unit/benchmarks/test_coverage_benchmark.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+
+from benchmarks.test_coverage.coverage_benchmark import (
+    calculate_coverage,
+    collect_tests,
+    parse_test_file,
+    sanitize_endpoint,
+)
+
+
+SAMPLE_TS = """
+describe('User Suite', () => {
+  it('should get user', () => {});
+  it('extra test', () => {});
+});
+"""
+
+
+def test_parse_test_file(tmp_path):
+    f = tmp_path / "GET-sample.spec.ts"
+    f.write_text(SAMPLE_TS)
+    tests = parse_test_file(str(f))
+    assert tests == [
+        "User Suite::should get user",
+        "User Suite::extra test",
+    ]
+
+
+def test_collect_and_calculate(tmp_path):
+    framework = tmp_path / "fw"
+    test_dir = framework / "src" / "tests" / sanitize_endpoint("/user")
+    test_dir.mkdir(parents=True)
+    (test_dir / "GET-sample.spec.ts").write_text(SAMPLE_TS)
+
+    gt_tests = ["User Suite::should get user"]
+    actual = collect_tests(str(framework), "/user", "get")
+    result = calculate_coverage(gt_tests, actual)
+
+    assert result["coverage_percent"] == 100.0
+    assert "User Suite::extra test" in result["extra_tests"]


### PR DESCRIPTION
## Summary
- add new benchmark `coverage_benchmark.py` to compare generated tests with an ideal set
- provide sample ground truth data
- document new benchmark usage in `benchmarks/README.md`
- test coverage benchmark utility
