### PR TITLE
Support for Anthropic models on AWS Bedrock

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,5 +1,7 @@
 OPENAI_API_KEY=your_openai_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
+AWS_ACCESS_KEY_ID=your_aws_access_key_id_here
+AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key_here
 MODEL=claude-sonnet-4-20250514 # requires Anthropic API key
 ENV=DEV # or PROD
 DEBUG=False # Set to True to enable debug mode in the terminal

--- a/src/configuration/config.py
+++ b/src/configuration/config.py
@@ -25,6 +25,8 @@ class Config:
     generate: GenerationOptions = GenerationOptions.MODELS_AND_TESTS
     anthropic_api_key: str = ""
     openai_api_key: str = ""
+    aws_access_key_id: str = ""
+    aws_secret_access_key: str = ""
     api_definition: str = ""
     data_source: str = ""
     destination_folder: str = ""

--- a/src/configuration/models.py
+++ b/src/configuration/models.py
@@ -2,36 +2,59 @@ from enum import Enum
 from typing import NamedTuple
 
 
+class Provider(Enum):
+    OPENAI = "openai"
+    ANTHROPIC = "anthropic"
+    BEDROCK = "bedrock"
+
+
 class ModelCost(NamedTuple):
     input_cost_per_million_tokens: float
     output_cost_per_million_tokens: float
 
 
 class Model(Enum):
-    GPT_4_O = ("gpt-4o", ModelCost(input_cost_per_million_tokens=2.5, output_cost_per_million_tokens=10.0))
-    GPT_4_1 = ("gpt-4.1", ModelCost(input_cost_per_million_tokens=2.0, output_cost_per_million_tokens=8.0))
+    GPT_4_O = (
+        "gpt-4o",
+        ModelCost(input_cost_per_million_tokens=2.5, output_cost_per_million_tokens=10.0),
+        Provider.OPENAI,
+    )
+    GPT_4_1 = (
+        "gpt-4.1",
+        ModelCost(input_cost_per_million_tokens=2.0, output_cost_per_million_tokens=8.0),
+        Provider.OPENAI,
+    )
     O3 = (
         "o3",
         ModelCost(input_cost_per_million_tokens=2.0, output_cost_per_million_tokens=8.0),
+        Provider.OPENAI,
     )
-    O4_MINI = ("o4-mini", ModelCost(input_cost_per_million_tokens=1.1, output_cost_per_million_tokens=4.4))
     CLAUDE_SONNET_3_5 = (
         "claude-3-5-sonnet-latest",
         ModelCost(input_cost_per_million_tokens=3.0, output_cost_per_million_tokens=15.0),
+        Provider.ANTHROPIC,
     )
     CLAUDE_SONNET_3_7 = (
         "claude-3-7-sonnet-latest",
         ModelCost(input_cost_per_million_tokens=3.0, output_cost_per_million_tokens=15.0),
+        Provider.ANTHROPIC,
     )
     CLAUDE_SONNET_4 = (
         "claude-sonnet-4-20250514",
         ModelCost(input_cost_per_million_tokens=3.0, output_cost_per_million_tokens=15.0),
+        Provider.ANTHROPIC,
+    )
+    CLAUDE_3_5_SONNET_BEDROCK = (
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        ModelCost(input_cost_per_million_tokens=3.0, output_cost_per_million_tokens=15.0),
+        Provider.BEDROCK,
     )
 
-    def __new__(cls, value, cost: ModelCost):
+    def __new__(cls, value, cost: ModelCost, provider: Provider):
         obj = object.__new__(cls)
         obj._value_ = value
         obj.cost = cost
+        obj.provider = provider
         return obj
 
     @property


### PR DESCRIPTION
This (draft) PR adds the option to use Anthropic models from AWS Bedrock.
Bedrock is accessed through an AWS access key pair (ID & Secret).
Each model on the Models enum now have an associated provider needed for proper client initialization and .env key lookup.